### PR TITLE
deps: remove dependency to `pedantic`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [4.0.1] - 2022-03-07
+
+* Removed deprecated `pedantic` dependency (in favor of `flutter_lints`).
+
 ## [4.0.0] - 2021-05-31
 
 * Migrated the package to null safety.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,1 +1,1 @@
-include: package:pedantic/analysis_options.yaml
+include: package:flutter_lints/flutter.yaml

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -1,0 +1,9 @@
+include: package:flutter_lints/flutter.yaml
+
+linter:
+  # in the example project, we are a bit less strict
+  rules:
+    use_key_in_widget_constructors: false
+    prefer_const_constructors_in_immutables: false
+    prefer_const_constructors: false
+    prefer_const_literals_to_create_immutables: false

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -80,7 +80,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "4.0.0"
+    version: "4.0.1"
   lints:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,14 +21,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -62,6 +62,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_lints:
+    dependency: "direct dev"
+    description:
+      name: flutter_lints
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.4"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -74,20 +81,27 @@ packages:
       relative: true
     source: path
     version: "4.0.0"
+  lints:
+    dependency: transitive
+    description:
+      name: lints
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
@@ -95,13 +109,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.0"
-  pedantic:
-    dependency: transitive
-    description:
-      name: pedantic
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.11.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -148,7 +155,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.4.3"
   typed_data:
     dependency: transitive
     description:
@@ -162,6 +169,6 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  flutter_lints: ^1.0.4
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,14 +21,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -55,25 +55,39 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_lints:
+    dependency: "direct dev"
+    description:
+      name: flutter_lints
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.4"
   flutter_test:
     dependency: "direct dev"
     description: flutter
     source: sdk
     version: "0.0.0"
+  lints:
+    dependency: transitive
+    description:
+      name: lints
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
@@ -81,13 +95,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.0"
-  pedantic:
-    dependency: "direct main"
-    description:
-      name: pedantic
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.11.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -134,7 +141,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.4.3"
   typed_data:
     dependency: transitive
     description:
@@ -148,6 +155,6 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: horizontal_blocked_scroll_physics
 description: A ScrollPhysics class that blocks movement in the horizontal axis.
-version: 4.0.0
+version: 4.0.1
 homepage: https://github.com/Alpha-health/horizontal_blocked_scroll_physics
 repository: https://github.com/Alpha-health/horizontal_blocked_scroll_physics
 issue_tracker: https://github.com/Alpha-health/horizontal_blocked_scroll_physics/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,9 +12,8 @@ dependencies:
   flutter:
     sdk: flutter
 
-  pedantic: ^1.11.0
-
 dev_dependencies:
+  flutter_lints: ^1.0.4
   flutter_test:
     sdk: flutter
 

--- a/test/horizontal_blocked_scroll_physics_test.dart
+++ b/test/horizontal_blocked_scroll_physics_test.dart
@@ -105,25 +105,25 @@ MovementResult moveRightNotInLeftRange(HorizontalBlockedScrollPhysics hs) {
 void main() {
   group('HorizontalBlockScrollPhysics', () {
     test('won\'t block by default', () {
-      var hs = HorizontalBlockedScrollPhysics();
+      const hs = HorizontalBlockedScrollPhysics();
       expect(hs.blockLeftMovement, false);
       expect(hs.blockRightMovement, false);
     });
 
     test('constructor will set blockLeftMovement', () {
-      var hs = HorizontalBlockedScrollPhysics(blockLeftMovement: true);
+      const hs = HorizontalBlockedScrollPhysics(blockLeftMovement: true);
       expect(hs.blockLeftMovement, true);
       expect(hs.blockRightMovement, false);
     });
 
     test('constructor will set blockRightMovement', () {
-      var hs = HorizontalBlockedScrollPhysics(blockRightMovement: true);
+      const hs = HorizontalBlockedScrollPhysics(blockRightMovement: true);
       expect(hs.blockLeftMovement, false);
       expect(hs.blockRightMovement, true);
     });
 
     test('movement won\'t be blocked by default', () {
-      var hs = HorizontalBlockedScrollPhysics();
+      const hs = HorizontalBlockedScrollPhysics();
 
       var position = FixedScrollMetrics(
         pixels: 10,
@@ -142,7 +142,7 @@ void main() {
     test(
         'blockLeftMovement won\'t block movement to the left while not in the left range',
         () {
-      var hs = HorizontalBlockedScrollPhysics(blockLeftMovement: true);
+      const hs = HorizontalBlockedScrollPhysics(blockLeftMovement: true);
       var result = moveLeftNotInLeftRange(hs);
       expect(result.hasNotBeenBlocked, true);
     });
@@ -150,7 +150,7 @@ void main() {
     test(
         'blockRightMovement won\'t block movement to the right while in the left range',
         () {
-      var hs = HorizontalBlockedScrollPhysics(blockRightMovement: true);
+      const hs = HorizontalBlockedScrollPhysics(blockRightMovement: true);
       var result = moveRightInLeftRange(hs);
       expect(result.hasNotBeenBlocked, true);
     });
@@ -158,7 +158,7 @@ void main() {
     test(
         'blockLeftMovement will block movement to the left while in the left range',
         () {
-      var hs = HorizontalBlockedScrollPhysics(blockLeftMovement: true);
+      const hs = HorizontalBlockedScrollPhysics(blockLeftMovement: true);
       var result = moveLeftInLeftRange(hs);
       expect(result.hasBeenBlocked, true);
     });
@@ -166,7 +166,7 @@ void main() {
     test(
         'blockRightMovement will block movement to the right while not in the left range',
         () {
-      var hs = HorizontalBlockedScrollPhysics(blockRightMovement: true);
+      const hs = HorizontalBlockedScrollPhysics(blockRightMovement: true);
       var result = moveRightNotInLeftRange(hs);
       expect(result.hasBeenBlocked, true);
     });
@@ -174,7 +174,7 @@ void main() {
     test(
         'blockRightMovement and blockLeftMovement will block all movement except right in left range and left not in left range',
         () {
-      var hs = HorizontalBlockedScrollPhysics(
+      const hs = HorizontalBlockedScrollPhysics(
         blockRightMovement: true,
         blockLeftMovement: true,
       );
@@ -200,19 +200,19 @@ void main() {
 
   group('LeftBlockedScrollPhysics', () {
     test('constructor will set blockLeftMovement', () {
-      var hs = LeftBlockedScrollPhysics();
+      const hs = LeftBlockedScrollPhysics();
       expect(hs.blockLeftMovement, true);
       expect(hs.blockRightMovement, false);
     });
 
     test('won\'t block movement to the left while not in the left range', () {
-      var hs = LeftBlockedScrollPhysics();
+      const hs = LeftBlockedScrollPhysics();
       var result = moveLeftNotInLeftRange(hs);
       expect(result.hasNotBeenBlocked, true);
     });
 
     test('will block movement to the left while in the left range', () {
-      var hs = LeftBlockedScrollPhysics();
+      const hs = LeftBlockedScrollPhysics();
       var result = moveLeftInLeftRange(hs);
       expect(result.hasBeenBlocked, true);
     });
@@ -220,19 +220,19 @@ void main() {
 
   group('RightBlockedScrollPhysics', () {
     test('constructor will set blockRightMovement', () {
-      var hs = RightBlockedScrollPhysics();
+      const hs = RightBlockedScrollPhysics();
       expect(hs.blockLeftMovement, false);
       expect(hs.blockRightMovement, true);
     });
 
     test('won\'t block movement to the right while in the left range', () {
-      var hs = RightBlockedScrollPhysics();
+      const hs = RightBlockedScrollPhysics();
       var result = moveRightInLeftRange(hs);
       expect(result.hasNotBeenBlocked, true);
     });
 
     test('will block movement to the right while not in the left range', () {
-      var hs = RightBlockedScrollPhysics();
+      const hs = RightBlockedScrollPhysics();
       var result = moveRightNotInLeftRange(hs);
       expect(result.hasBeenBlocked, true);
     });


### PR DESCRIPTION
`pedantic` is deprecated, and has been superseeded by `flutter_lints`

See also : 
- Introducing `flutter_lints`  https://docs.flutter.dev/release/breaking-changes/flutter-lints-package
- Migration instructions :  https://github.com/dart-lang/lints#migrating-from-packagepedantic


I thought this library actually relied on `unawaited` from `pedantic` , but it doesn't ... still migrated to recommended linters, which hopefully will also help increase the score on `pub.dev`

Cheers !

fixes #8